### PR TITLE
Fix markdown rendering, tokenization edge cases, and window focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "obsidian-sample-plugin",
-	"version": "1.0.0",
+	"name": "obsidian-speed-reader",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-sample-plugin",
-			"version": "1.0.0",
+			"name": "obsidian-speed-reader",
+			"version": "1.1.0",
 			"license": "0-BSD",
 			"dependencies": {
 				"obsidian": "latest"
@@ -18,32 +18,249 @@
 				"eslint-plugin-obsidianmd": "0.1.9",
 				"globals": "14.0.0",
 				"jiti": "2.6.1",
+				"jsdom": "^29.0.2",
 				"tslib": "2.4.0",
 				"typescript": "^5.8.3",
-				"typescript-eslint": "8.35.1"
+				"typescript-eslint": "8.35.1",
+				"vitest": "^4.1.5"
 			}
 		},
-		"node_modules/@codemirror/state": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
-			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@marijn/find-cluster-break": "^1.0.0"
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@codemirror/view": {
-			"version": "6.38.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
-			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@codemirror/state": "^6.5.0",
-				"crelt": "^1.0.6",
-				"style-mod": "^4.1.0",
-				"w3c-keyname": "^2.2.4"
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -584,29 +801,11 @@
 			"integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
-			}
-		},
-		"node_modules/@eslint/json": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.14.0.tgz",
-			"integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@eslint/core": "^0.17.0",
-				"@eslint/plugin-kit": "^0.4.1",
-				"@humanwhocodes/momoa": "^3.3.10",
-				"natural-compare": "^1.4.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
@@ -631,6 +830,24 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -671,16 +888,6 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@humanwhocodes/momoa": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
-			"integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
@@ -695,10 +902,11 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@marijn/find-cluster-break": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@microsoft/eslint-plugin-sdl": {
@@ -739,6 +947,25 @@
 				"ret": "~0.1.10"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -777,6 +1004,16 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
 		"node_modules/@pkgr/core": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
@@ -790,12 +1027,305 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
 			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
 		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
@@ -805,6 +1335,13 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/eslint": {
 			"version": "8.56.2",
@@ -899,7 +1436,6 @@
 			"integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.35.1",
 				"@typescript-eslint/types": "8.35.1",
@@ -1124,13 +1660,125 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.5",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.5",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.5",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1348,6 +1996,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1380,6 +2038,16 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -1465,6 +2133,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1509,10 +2187,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/crelt": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
@@ -1528,6 +2207,34 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/data-view-buffer": {
@@ -1602,6 +2309,13 @@
 				}
 			}
 		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1643,6 +2357,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/doctrine": {
@@ -1695,6 +2419,19 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/es-abstract": {
@@ -1813,6 +2550,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -1934,7 +2678,6 @@
 			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -2546,6 +3289,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2554,6 +3307,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2634,6 +3397,24 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2712,6 +3493,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/function-bind": {
@@ -2997,6 +3793,19 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -3298,6 +4107,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3481,7 +4297,6 @@
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -3504,6 +4319,47 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+			"integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.5",
+				"@asamuzakjp/dom-selector": "^7.0.6",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.2.7",
+				"parse5": "^8.0.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.24.5",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/json-buffer": {
@@ -3677,6 +4533,267 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3713,6 +4830,26 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3722,6 +4859,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -3792,6 +4936,25 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -3937,6 +5100,17 @@
 				"@codemirror/view": "6.38.6"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4018,6 +5192,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4045,6 +5232,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4066,6 +5267,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.11",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.11.tgz",
+			"integrity": "sha512-5dDj8+lmvA8XB78SmzGI8NlQoksv7IfutGWeVZxiixHbO+p4LDPT3wuG/D9sM/wrjZZ9I+Siy/e117vbFPxSZg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -4254,6 +5484,40 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.127.0",
+				"@rolldown/pluginutils": "1.0.0-rc.17"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4362,6 +5626,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
 			}
 		},
 		"node_modules/semver": {
@@ -4522,6 +5799,37 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -4657,12 +5965,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/style-mod": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
-			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-			"license": "MIT"
-		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4688,6 +5990,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/synckit": {
 			"version": "0.9.3",
@@ -4726,6 +6035,83 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+			"integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.28"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+			"integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -4767,6 +6153,32 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -4912,7 +6324,6 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4927,7 +6338,6 @@
 			"integrity": "sha512-xslJjFzhOmHYQzSB/QTeASAHbjmxOGEP6Coh93TXmUBFQoJ1VU35UHIDmG06Jd6taf3wqqC1ntBnCMeymy5Ovw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/eslint-plugin": "8.35.1",
 				"@typescript-eslint/parser": "8.35.1",
@@ -4964,6 +6374,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -4981,11 +6401,247 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/w3c-keyname": {
-			"version": "2.2.8",
-			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"license": "MIT"
+		"node_modules/vite": {
+			"version": "8.0.10",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.10",
+				"rolldown": "1.0.0-rc.17",
+				"tinyglobby": "^0.2.16"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.5",
+				"@vitest/mocker": "4.1.5",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/runner": "4.1.5",
+				"@vitest/snapshot": "4.1.5",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.5",
+				"@vitest/browser-preview": "4.1.5",
+				"@vitest/browser-webdriverio": "4.1.5",
+				"@vitest/coverage-istanbul": "4.1.5",
+				"@vitest/coverage-v8": "4.1.5",
+				"@vitest/ui": "4.1.5",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -5092,6 +6748,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5101,6 +6774,23 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yaml": {
 			"version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,17 @@
 	"keywords": [],
 	"license": "0-BSD",
 	"devDependencies": {
+		"@eslint/js": "9.30.1",
 		"@types/node": "^16.11.6",
 		"esbuild": "0.25.5",
 		"eslint-plugin-obsidianmd": "0.1.9",
 		"globals": "14.0.0",
+		"jiti": "2.6.1",
+		"jsdom": "^29.0.2",
 		"tslib": "2.4.0",
 		"typescript": "^5.8.3",
 		"typescript-eslint": "8.35.1",
-		"@eslint/js": "9.30.1",
-		"jiti": "2.6.1"
+		"vitest": "^4.1.5"
 	},
 	"dependencies": {
 		"obsidian": "latest"

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,6 @@ export default class SpeedReaderPlugin extends Plugin {
 			}
 		});
 
-		// Command: Speed read selection
 		this.addCommand({
 			id: 'speed-read-selection',
 			name: 'Speed read selected text',
@@ -98,14 +97,14 @@ export default class SpeedReaderPlugin extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	private startSpeedReading(view: MarkdownView, forceWholeNote = false) {
+	private startSpeedReading(view: MarkdownView, fromCursor = false) {
 		const editor = view.editor;
 		let text = editor.getSelection();
 		let startOffset = 0;
 
-		if (forceWholeNote || !text || text.length === 0) {
+		if (!text || text.length === 0) {
 			text = editor.getValue();
-			startOffset = editor.posToOffset(editor.getCursor());
+			startOffset = fromCursor ? editor.posToOffset(editor.getCursor()) : 0;
 		}
 
 		if (!text || text.trim().length === 0) {

--- a/src/services/settingsValidator.ts
+++ b/src/services/settingsValidator.ts
@@ -24,6 +24,7 @@ export function validateSettings(raw: Partial<SpeedReaderSettings> | null | unde
 	return {
 		wpm: clamp(Math.round(toNumber(settings.wpm, DEFAULT_SETTINGS.wpm)), 50, 5000),
 		chunkSize: clamp(Math.round(toNumber(settings.chunkSize, DEFAULT_SETTINGS.chunkSize)), 1, 5),
+		fontSize: clamp(Math.round(toNumber(settings.fontSize, DEFAULT_SETTINGS.fontSize)), 24, 200),
 		showContext: toBoolean(settings.showContext, DEFAULT_SETTINGS.showContext),
 		contextWords: clamp(Math.round(toNumber(settings.contextWords, DEFAULT_SETTINGS.contextWords)), 1, 10),
 		showProgress: toBoolean(settings.showProgress, DEFAULT_SETTINGS.showProgress),

--- a/src/services/textParser.ts
+++ b/src/services/textParser.ts
@@ -16,28 +16,97 @@ function stripTrailingPunctuation(word: string): { clean: string; punctuation: s
 	return { clean: word, punctuation: '' };
 }
 
-function parseWords(text: string): WordData[] {
-	const words: WordData[] = [];
-	const matcher = /\S+/g;
-	let match = matcher.exec(text);
+function stripMarkdown(text: string): string {
+	let result = text;
+
+	result = result.replace(/^---[\s\S]*?---\n?/gm, '');
+
+	result = result.replace(/^```[\s\S]*?^```/gm, '');
+	result = result.replace(/```[\s\S]*?```/g, '');
+
+	result = result.replace(/`([^`]+)`/g, '$1');
+
+	result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+
+	result = result.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+
+	result = result.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, target, display) => {
+		return display ?? target;
+	});
+
+	result = result.replace(/^(#{1,6})\s+/gm, '');
+
+	result = result.replace(/\*\*\*([^*]+)\*\*\*/g, '$1');
+	result = result.replace(/___([^_\n]+)___/g, '$1');
+	result = result.replace(/\*\*([^*]+)\*\*/g, '$1');
+	result = result.replace(/(?<!\w)__([^_\n]+)__(?!\w)/g, '$1');
+	result = result.replace(/(?<!\w)\*([^*]+)\*(?!\w)/g, '$1');
+	result = result.replace(/(?<!\w)_([^_\n]+)_(?!\w)/g, '$1');
+
+	result = result.replace(/~~([^~]+)~~/g, '$1');
+	result = result.replace(/==([^=]+)==/g, '$1');
+	result = result.replace(/%%([^%]+)%%/g, '');
+
+	result = result.replace(/^[-*+]\s+/gm, ' ');
+	result = result.replace(/^\d+\.\s+/gm, ' ');
+	result = result.replace(/^>\s+/gm, '');
+
+	result = result.replace(/^---+\s*$/gm, '');
+	result = result.replace(/^-{3,}\s*$/gm, '');
+
+	return result;
+}
+
+function tokenize(text: string): { raw: string; start: number }[] {
+	const tokens: { raw: string; start: number }[] = [];
+	const pattern = /\S+/g;
+	let match = pattern.exec(text);
 
 	while (match !== null) {
-		const raw = match[0];
-		const start = match.index;
-		const end = start + raw.length;
-		const stripped = stripTrailingPunctuation(raw);
-		const displayWord = stripped.clean.length > 0 ? stripped.clean : raw;
+		tokens.push({ raw: match[0], start: match.index });
+		match = pattern.exec(text);
+	}
+
+	return tokens;
+}
+
+function stripLeadingPunctuation(word: string): { clean: string; leading: string } {
+	const match = word.match(/^([([{'"(]+)(.+)$/);
+	if (match && match[1] && match[2]) {
+		return { clean: match[2], leading: match[1] };
+	}
+	return { clean: word, leading: '' };
+}
+
+function parseWords(strippedText: string): WordData[] {
+	const words: WordData[] = [];
+	const tokens = tokenize(strippedText);
+
+	for (const token of tokens) {
+		const { raw, start } = token;
+		let displayWord = raw;
+		let punctuation = '';
+
+		if (raw.startsWith('(') && raw.endsWith(')') && raw.length > 2) {
+			displayWord = raw.slice(1, -1);
+			const inner = stripTrailingPunctuation(displayWord);
+			displayWord = inner.clean.length > 0 ? inner.clean : displayWord;
+			punctuation = inner.punctuation;
+		} else {
+			const leadingStripped = stripLeadingPunctuation(raw);
+			const trailingStripped = stripTrailingPunctuation(leadingStripped.clean);
+			displayWord = trailingStripped.clean.length > 0 ? trailingStripped.clean : leadingStripped.clean;
+			punctuation = trailingStripped.punctuation;
+		}
 
 		words.push({
 			raw,
 			word: displayWord,
-			punctuation: stripped.punctuation,
+			punctuation,
 			orpIndex: calculateORP(displayWord),
 			start,
-			end
+			end: start + raw.length
 		});
-
-		match = matcher.exec(text);
 	}
 
 	return words;
@@ -98,7 +167,8 @@ function extractHeadings(text: string, words: WordData[]): HeadingInfo[] {
 }
 
 export function parseDocument(text: string, startOffset = 0): ParsedDocument {
-	const words = parseWords(text);
+	const strippedText = stripMarkdown(text);
+	const words = parseWords(strippedText);
 	const headings = extractHeadings(text, words);
 	const boundedStartOffset = Math.max(0, startOffset);
 	const startWordIndex = findWordIndexAtOffset(words, boundedStartOffset);
@@ -109,3 +179,5 @@ export function parseDocument(text: string, startOffset = 0): ParsedDocument {
 		startWordIndex
 	};
 }
+
+export { stripMarkdown };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -123,6 +123,20 @@ export class SpeedReaderSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl).setName('Display').setHeading();
 
+		this.addSliderWithInput(
+			containerEl,
+			'Font size',
+			'Word font size in pixels.',
+			24,
+			200,
+			2,
+			this.plugin.settings.fontSize,
+			async (value) => {
+				this.plugin.settings.fontSize = value;
+				await this.plugin.saveSettings();
+			}
+		);
+
 		new Setting(containerEl)
 			.setName('Show context')
 			.setDesc('Display surrounding words around the active chunk.')

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface HeadingInfo {
 export interface SpeedReaderSettings {
 	wpm: number;
 	chunkSize: number;
+	fontSize: number;
 	showContext: boolean;
 	contextWords: number;
 	showProgress: boolean;
@@ -54,6 +55,7 @@ export interface ParsedDocument {
 export const DEFAULT_SETTINGS: SpeedReaderSettings = {
 	wpm: 300,
 	chunkSize: 1,
+	fontSize: 64,
 	showContext: false,
 	contextWords: 3,
 	showProgress: true,

--- a/src/ui/readerModalView.ts
+++ b/src/ui/readerModalView.ts
@@ -29,6 +29,9 @@ export class SpeedReaderModal extends Modal {
 	private engine: RSVPEngine;
 	private focusMode = false;
 	private state: ReaderState | null = null;
+	private wasPlayingBeforeBlur = false;
+	private boundVisibilityHandler: () => void;
+	private boundBlurHandler: () => void;
 
 	private wordContainer!: HTMLElement;
 	private statsEl!: HTMLElement;
@@ -50,6 +53,8 @@ export class SpeedReaderModal extends Modal {
 		this.settings = settings;
 		this.onSettingsChange = onSettingsChange;
 		this.startOffset = startOffset;
+		this.boundVisibilityHandler = () => this.handleVisibilityChange();
+		this.boundBlurHandler = () => this.handleWindowBlur();
 		this.engine = new RSVPEngine(
 			this.settings,
 			(state) => {
@@ -67,8 +72,11 @@ export class SpeedReaderModal extends Modal {
 		modalEl.addClass('speed-reader-modal');
 		contentEl.empty();
 		contentEl.addClass('speed-reader-content');
+		contentEl.setAttr('tabindex', '-1');
+		contentEl.focus();
 
 		this.wordContainer = contentEl.createDiv({ cls: 'speed-reader-word-container' });
+		this.wordContainer.style.setProperty('--speed-reader-font-size', `${this.settings.fontSize}px`);
 		this.contextEl = contentEl.createDiv({ cls: 'speed-reader-context' });
 		this.statsEl = contentEl.createDiv({ cls: 'speed-reader-stats' });
 
@@ -79,12 +87,14 @@ export class SpeedReaderModal extends Modal {
 		this.controlsEl = contentEl.createDiv({ cls: 'speed-reader-controls' });
 
 		this.registerKeyboardHandlers();
+		this.registerFocusHandlers();
 		this.engine.loadText(this.sourceText, this.startOffset);
 		this.buildHeadingSelector();
-		this.engine.play();
 	}
 
 	onClose() {
+		document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
+		window.removeEventListener('blur', this.boundBlurHandler);
 		this.engine.pause();
 		this.onSettingsChange(this.settings);
 		this.contentEl.empty();
@@ -134,6 +144,48 @@ export class SpeedReaderModal extends Modal {
 			this.close();
 			return false;
 		});
+
+		this.contentEl.addEventListener('keydown', (event) => {
+			if (event.key === ' ') {
+				event.preventDefault();
+				this.engine.togglePlayPause();
+			}
+		});
+	}
+
+	private registerFocusHandlers() {
+		document.addEventListener('visibilitychange', this.boundVisibilityHandler);
+		window.addEventListener('blur', this.boundBlurHandler);
+	}
+
+	private handleVisibilityChange() {
+		if (document.hidden) {
+			this.pauseIfPlaying();
+		} else if (this.wasPlayingBeforeBlur) {
+			this.wasPlayingBeforeBlur = false;
+			this.engine.play();
+		}
+	}
+
+	private handleWindowBlur() {
+		if (!document.hidden) {
+			this.pauseIfPlaying();
+		}
+	}
+
+	private pauseIfPlaying() {
+		const state = this.state;
+		if (state?.isPlaying) {
+			this.wasPlayingBeforeBlur = true;
+			this.engine.pause();
+		}
+	}
+
+	private refocusContent() {
+		const active = document.activeElement;
+		if (active instanceof HTMLButtonElement || active instanceof HTMLSelectElement) {
+			this.contentEl.focus();
+		}
 	}
 
 	private buildHeadingSelector() {
@@ -158,6 +210,7 @@ export class SpeedReaderModal extends Modal {
 			}
 
 			this.sectionSelect.value = '';
+			this.refocusContent();
 		});
 	}
 
@@ -174,6 +227,7 @@ export class SpeedReaderModal extends Modal {
 
 		const percentage = (event.clientX - rect.left) / rect.width;
 		this.engine.seekToPercent(percentage);
+		this.refocusContent();
 	}
 
 	private render() {
@@ -232,15 +286,18 @@ export class SpeedReaderModal extends Modal {
 			cls: 'speed-reader-play-btn',
 			text: state.isPlaying ? '⏸' : '▶'
 		});
-		playPause.addEventListener('click', () => this.engine.togglePlayPause());
+		playPause.addEventListener('click', () => {
+			this.engine.togglePlayPause();
+			this.refocusContent();
+		});
 
 		const speedGroup = this.statsEl.createDiv({ cls: 'speed-reader-speed-control' });
 		const decrease = speedGroup.createEl('button', { cls: 'speed-reader-speed-btn', text: '−' });
-		decrease.addEventListener('click', () => this.adjustWpm(-25));
+		decrease.addEventListener('click', () => { this.adjustWpm(-25); this.refocusContent(); });
 		speedGroup.createSpan({ cls: 'speed-reader-wpm', text: String(Math.round(state.currentWpm)) });
 		speedGroup.createSpan({ cls: 'speed-reader-wpm-label', text: 'WPM' });
 		const increase = speedGroup.createEl('button', { cls: 'speed-reader-speed-btn', text: '+' });
-		increase.addEventListener('click', () => this.adjustWpm(25));
+		increase.addEventListener('click', () => { this.adjustWpm(25); this.refocusContent(); });
 
 		const progressInfo = this.statsEl.createDiv({ cls: 'speed-reader-progress-info' });
 		const currentWord = Math.min(state.currentIndex + 1, state.totalWords);

--- a/styles.css
+++ b/styles.css
@@ -85,7 +85,7 @@
 	gap: 0.45rem;
 	flex-wrap: wrap;
 	font-family: var(--font-text);
-	font-size: clamp(2.5rem, 8vw, 4rem);
+	font-size: var(--speed-reader-font-size, clamp(2.5rem, 8vw, 4rem));
 	font-weight: 500;
 	color: var(--text-normal);
 	letter-spacing: 0.02em;
@@ -109,7 +109,7 @@
 
 .speed-reader-left {
 	text-align: right;
-	min-width: clamp(50px, 15vw, 180px);
+	min-width: calc(var(--speed-reader-font-size, 4rem) * 1.5);
 	color: var(--text-muted);
 }
 
@@ -120,7 +120,7 @@
 
 .speed-reader-right {
 	text-align: left;
-	min-width: clamp(50px, 15vw, 180px);
+	min-width: calc(var(--speed-reader-font-size, 4rem) * 1.5);
 	color: var(--text-muted);
 }
 
@@ -470,6 +470,7 @@
 	.speed-reader-word-container {
 		min-height: 120px;
 		padding: 1rem;
+		--speed-reader-font-size: clamp(2rem, 6vw, 3rem);
 	}
 
 	.speed-reader-stats {

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RSVPEngine } from '../src/engine/rsvpEngine';
+import { DEFAULT_SETTINGS } from '../src/types';
+import type { SpeedReaderSettings, ReaderState } from '../src/types';
+
+describe('RSVPEngine', () => {
+	let engine: RSVPEngine;
+	let stateChanges: ReaderState[];
+	let Completes: number[];
+	const settings: SpeedReaderSettings = { ...DEFAULT_SETTINGS };
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		stateChanges = [];
+		Completes = [];
+		engine = new RSVPEngine(
+			settings,
+			(state) => stateChanges.push(state),
+			() => Completes.push(1)
+		);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('loads text and parses words', () => {
+		engine.loadText('Hello world');
+		expect(stateChanges.length).toBeGreaterThan(0);
+		expect(stateChanges[0]!.totalWords).toBe(2);
+	});
+
+	it('starts playing when play() is called', () => {
+		engine.loadText('One two three');
+		engine.play();
+		expect(stateChanges[stateChanges.length - 1]!.isPlaying).toBe(true);
+	});
+
+	it('pauses when pause() is called', () => {
+		engine.loadText('One two three');
+		engine.play();
+		engine.pause();
+		expect(stateChanges[stateChanges.length - 1]!.isPlaying).toBe(false);
+	});
+
+	it('toggles play/pause', () => {
+		engine.loadText('One two three');
+		engine.togglePlayPause();
+		expect(stateChanges[stateChanges.length - 1]!.isPlaying).toBe(true);
+		engine.togglePlayPause();
+		expect(stateChanges[stateChanges.length - 1]!.isPlaying).toBe(false);
+	});
+
+	it('advances words on timeout', () => {
+		engine.loadText('One two three four five');
+		engine.play();
+		const initialIndex = stateChanges[0]!.currentIndex;
+		vi.advanceTimersByTime(2000);
+		const laterIndex = stateChanges[stateChanges.length - 1]!.currentIndex;
+		expect(laterIndex).toBeGreaterThan(initialIndex);
+	});
+
+	it('resumes from beginning after finishing', () => {
+		engine.loadText('One');
+		engine.play();
+		vi.advanceTimersByTime(1000);
+		expect(stateChanges.some(s => s.finished)).toBe(true);
+		engine.play();
+		expect(stateChanges[stateChanges.length - 1]!.currentIndex).toBe(0);
+	});
+
+	it('adjusts WPM', () => {
+		engine.loadText('Hello');
+		const newWpm = engine.adjustWpm(50);
+		expect(newWpm).toBe(DEFAULT_SETTINGS.wpm + 50);
+	});
+
+	it('clamps WPM to min 50', () => {
+		engine.loadText('Hello');
+		const newWpm = engine.adjustWpm(-500);
+		expect(newWpm).toBe(50);
+	});
+
+	it('clamps WPM to max 5000', () => {
+		engine.loadText('Hello');
+		const newWpm = engine.adjustWpm(5000);
+		expect(newWpm).toBe(5000);
+	});
+
+	it('rewinds by word count', () => {
+		engine.loadText('One two three four five');
+		engine.play();
+		vi.advanceTimersByTime(500);
+		engine.pause();
+		const beforeRewind = stateChanges[stateChanges.length - 1]!.currentIndex;
+		engine.rewind(2);
+		const afterRewind = stateChanges[stateChanges.length - 1]!.currentIndex;
+		expect(afterRewind).toBeLessThan(beforeRewind);
+	});
+
+	it('fast forwards by word count', () => {
+		engine.loadText('One two three four five');
+		engine.fastForward(2);
+		expect(stateChanges[stateChanges.length - 1]!.currentIndex).toBe(2);
+	});
+
+	it('seeks to percentage', () => {
+		engine.loadText('One two three four five six seven eight nine ten');
+		engine.seekToPercent(0.5);
+		expect(stateChanges[stateChanges.length - 1]!.currentIndex).toBe(5);
+	});
+
+	it('updates settings', () => {
+		engine.loadText('Hello');
+		const newSettings = { ...settings, wpm: 500 };
+		engine.setSettings(newSettings);
+		expect(engine.getSettings().wpm).toBe(500);
+	});
+
+	it('returns headings', () => {
+		engine.loadText('# Title\nSome text\n## Section\nMore text');
+		const headings = engine.getHeadings();
+		expect(headings.length).toBe(2);
+		expect(headings[0]!.level).toBe(1);
+		expect(headings[0]!.text).toBe('Title');
+		expect(headings[1]!.level).toBe(2);
+	});
+
+	it('getContext returns surrounding words', () => {
+		engine.loadText('One two three four five');
+		engine.seekToIndex(2);
+		const context = engine.getContext(1);
+		expect(context.before).toContain('two');
+		expect(context.after).toContain('four');
+	});
+
+	it('handles empty text', () => {
+		engine.loadText('');
+		expect(stateChanges[0]!.totalWords).toBe(0);
+	});
+
+	it('calculates progress', () => {
+		engine.loadText('One two three four five');
+		engine.seekToIndex(2);
+		const progress = stateChanges[stateChanges.length - 1]!.progress;
+		expect(progress).toBe(40);
+	});
+
+	it('engine starts paused after loadText', () => {
+		engine.loadText('One two three');
+		expect(stateChanges[stateChanges.length - 1]!.isPlaying).toBe(false);
+	});
+});
+
+describe('Visibility change auto-pause logic', () => {
+	it('should pause when document becomes hidden and resume on return', () => {
+		let wasPlayingBeforeBlur = false;
+		const isPlaying = { value: false };
+
+		const mockEngine = {
+			pause: vi.fn(() => { isPlaying.value = false; }),
+			play: vi.fn(() => { isPlaying.value = true; }),
+		};
+
+		isPlaying.value = true;
+
+		const visibilityHandler = () => {
+			if (document.hidden) {
+				if (isPlaying.value) {
+					wasPlayingBeforeBlur = true;
+					mockEngine.pause();
+				}
+			} else {
+				if (wasPlayingBeforeBlur) {
+					wasPlayingBeforeBlur = false;
+					mockEngine.play();
+				}
+			}
+		};
+
+		Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+		visibilityHandler();
+		expect(mockEngine.pause).toHaveBeenCalledTimes(1);
+		expect(wasPlayingBeforeBlur).toBe(true);
+
+		Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+		visibilityHandler();
+		expect(mockEngine.play).toHaveBeenCalledTimes(1);
+		expect(wasPlayingBeforeBlur).toBe(false);
+	});
+
+	it('should not resume if not playing before blur', () => {
+		let wasPlayingBeforeBlur = false;
+		const isPlaying = { value: false };
+		const mockEngine = {
+			pause: vi.fn(),
+			play: vi.fn(),
+		};
+
+		const visibilityHandler = () => {
+			if (document.hidden) {
+				if (isPlaying.value) {
+					wasPlayingBeforeBlur = true;
+					mockEngine.pause();
+				}
+			} else {
+				if (wasPlayingBeforeBlur) {
+					wasPlayingBeforeBlur = false;
+					mockEngine.play();
+				}
+			}
+		};
+
+		Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+		visibilityHandler();
+		expect(mockEngine.pause).not.toHaveBeenCalled();
+
+		Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+		visibilityHandler();
+		expect(mockEngine.play).not.toHaveBeenCalled();
+	});
+
+	});

--- a/tests/textParser.test.ts
+++ b/tests/textParser.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from 'vitest';
+import { stripMarkdown, parseDocument } from '../src/services/textParser';
+
+describe('stripMarkdown', () => {
+	it('strips YAML frontmatter', () => {
+		const input = '---\ntitle: My Note\ntags: [test]\n---\nHello world';
+		expect(stripMarkdown(input)).not.toContain('---');
+		expect(stripMarkdown(input)).toContain('Hello world');
+	});
+
+	it('strips fenced code blocks', () => {
+		const input = 'Before\n```js\nconst x = 1;\n```\nAfter';
+		const result = stripMarkdown(input);
+		expect(result).not.toContain('```');
+		expect(result).not.toContain('const');
+		expect(result).toContain('Before');
+		expect(result).toContain('After');
+	});
+
+	it('strips inline code', () => {
+		expect(stripMarkdown('Use `console.log` here')).toBe('Use console.log here');
+	});
+
+	it('strips bold markers', () => {
+		expect(stripMarkdown('This is **bold** text')).toBe('This is bold text');
+		expect(stripMarkdown('This is __bold__ text')).toBe('This is bold text');
+	});
+
+	it('strips italic markers', () => {
+		expect(stripMarkdown('This is *italic* text')).toBe('This is italic text');
+		expect(stripMarkdown('This is _italic_ text')).toBe('This is italic text');
+	});
+
+	it('strips bold+italic markers', () => {
+		expect(stripMarkdown('This is ***bold italic*** text')).toBe('This is bold italic text');
+	});
+
+	it('strips strikethrough', () => {
+		expect(stripMarkdown('This is ~~deleted~~ text')).toBe('This is deleted text');
+	});
+
+	it('strips highlights', () => {
+		expect(stripMarkdown('This is ==highlighted== text')).toBe('This is highlighted text');
+	});
+
+	it('strips comments', () => {
+		expect(stripMarkdown('This is %%hidden%% text')).toBe('This is  text');
+	});
+
+	it('strips markdown links keeping display text', () => {
+		expect(stripMarkdown('[Click here](https://example.com)')).toBe('Click here');
+	});
+
+	it('strips image syntax keeping alt text', () => {
+		expect(stripMarkdown('![Photo](image.png)')).toBe('Photo');
+	});
+
+	it('strips wiki links with display text', () => {
+		expect(stripMarkdown('See [[Some Note|Display Text]]')).toBe('See Display Text');
+	});
+
+	it('strips wiki links without display text', () => {
+		expect(stripMarkdown('See [[Some Note]]')).toBe('See Some Note');
+	});
+
+	it('strips heading markers', () => {
+		expect(stripMarkdown('# Heading 1')).toBe('Heading 1');
+		expect(stripMarkdown('## Heading 2')).toBe('Heading 2');
+		expect(stripMarkdown('### Heading 3')).toBe('Heading 3');
+	});
+
+	it('strips unordered list markers', () => {
+		expect(stripMarkdown('- Item one')).toBe(' Item one');
+		expect(stripMarkdown('* Item two')).toBe(' Item two');
+		expect(stripMarkdown('+ Item three')).toBe(' Item three');
+	});
+
+	it('strips ordered list markers', () => {
+		expect(stripMarkdown('1. First item')).toBe(' First item');
+		expect(stripMarkdown('42. Some item')).toBe(' Some item');
+	});
+
+	it('strips blockquote markers', () => {
+		expect(stripMarkdown('> Quoted text')).toBe('Quoted text');
+	});
+
+	it('handles plain text unchanged', () => {
+		expect(stripMarkdown('Hello world')).toBe('Hello world');
+	});
+
+	it('handles mixed markdown content', () => {
+		const input = '# Title\n\nThis is **bold** and *italic* with `code`.\n\n- Item one\n- Item two';
+		const result = stripMarkdown(input);
+		expect(result).not.toContain('#');
+		expect(result).not.toContain('**');
+		expect(result).not.toContain('*');
+		expect(result).not.toContain('`');
+		expect(result).toContain('Title');
+		expect(result).toContain('bold');
+		expect(result).toContain('italic');
+		expect(result).toContain('code');
+	});
+});
+
+describe('parseDocument', () => {
+	it('parses plain text into words', () => {
+		const doc = parseDocument('Hello world');
+		expect(doc.words.length).toBe(2);
+		expect(doc.words[0]!.word).toBe('Hello');
+		expect(doc.words[1]!.word).toBe('world');
+	});
+
+	it('strips markdown before tokenizing', () => {
+		const doc = parseDocument('This is **bold** text');
+		const boldWord = doc.words.find(w => w.word === 'bold');
+		expect(boldWord).toBeDefined();
+		expect(boldWord!.word).toBe('bold');
+	});
+
+	it('does not include raw markdown markers in words', () => {
+		const doc = parseDocument('Read the **important** section');
+		for (const word of doc.words) {
+			expect(word.word).not.toContain('**');
+			expect(word.raw).not.toContain('**');
+		}
+	});
+
+	it('strips heading # markers from word stream', () => {
+		const doc = parseDocument('# Introduction\nSome text here');
+		const hashWord = doc.words.find(w => w.word === '#' || w.raw === '#');
+		expect(hashWord).toBeUndefined();
+	});
+
+	it('still extracts headings with level info', () => {
+		const doc = parseDocument('# Introduction\nSome text here');
+		expect(doc.headings.length).toBe(1);
+		expect(doc.headings[0]!.level).toBe(1);
+		expect(doc.headings[0]!.text).toBe('Introduction');
+	});
+
+	it('handles wiki links in word stream', () => {
+		const doc = parseDocument('See [[My Notes]] for details');
+		const linkWord = doc.words.find(w => w.word.includes('[[') || w.word.includes(']]'));
+		expect(linkWord).toBeUndefined();
+		const displayWord = doc.words.find(w => w.word === 'My');
+		expect(displayWord).toBeDefined();
+	});
+
+	it('handles YAML frontmatter - no frontmatter words in output', () => {
+		const doc = parseDocument('---\ntitle: Test\ndate: 2024-01-01\n---\nContent here');
+		const fmWords = doc.words.filter(w => w.word === 'title:' || w.word === 'date:' || w.word === '---');
+		expect(fmWords.length).toBe(0);
+		expect(doc.words.some(w => w.word === 'Content')).toBe(true);
+	});
+
+	it('strips code fences from word stream', () => {
+		const doc = parseDocument('Before\n```\ncode here\n```\nAfter');
+		const codeWords = doc.words.filter(w => w.word === '```');
+		expect(codeWords.length).toBe(0);
+	});
+
+	it('handles inline code', () => {
+		const doc = parseDocument('Use `console.log` for debugging');
+		const codeWord = doc.words.find(w => w.word === 'console.log');
+		expect(codeWord).toBeDefined();
+		const backtickWord = doc.words.find(w => w.word.includes('`'));
+		expect(backtickWord).toBeUndefined();
+	});
+
+	it('handles markdown links', () => {
+		const doc = parseDocument('Click [here](https://example.com) now');
+		const linkWord = doc.words.find(w => w.word === 'here');
+		expect(linkWord).toBeDefined();
+		const urlWord = doc.words.find(w => w.word.includes('https') || w.word.includes('example.com'));
+		expect(urlWord).toBeUndefined();
+	});
+
+	it('preserves sentence-ending punctuation', () => {
+		const doc = parseDocument('Hello world.');
+		expect(doc.words[1]!.word).toBe('world');
+		expect(doc.words[1]!.punctuation).toBe('.');
+	});
+
+	it('preserves comma punctuation', () => {
+		const doc = parseDocument('Hello, world');
+		expect(doc.words[0]!.word).toBe('Hello');
+		expect(doc.words[0]!.punctuation).toBe(',');
+	});
+
+	it('calculates ORP correctly for short words', () => {
+		const doc = parseDocument('I am here');
+		expect(doc.words.find(w => w.word === 'I')!.orpIndex).toBe(0);
+		expect(doc.words.find(w => w.word === 'am')!.orpIndex).toBe(1);
+	});
+
+	it('calculates ORP correctly for longer words', () => {
+		const doc = parseDocument('important development');
+		expect(doc.words.find(w => w.word === 'important')!.orpIndex).toBe(2);
+		expect(doc.words.find(w => w.word === 'development')!.orpIndex).toBe(3);
+	});
+
+	it('respects startOffset', () => {
+		const doc = parseDocument('Hello beautiful world', 8);
+		expect(doc.startWordIndex).toBe(1);
+	});
+
+	it('handles empty text', () => {
+		const doc = parseDocument('');
+		expect(doc.words.length).toBe(0);
+	});
+
+	it('handles parenthetical words', () => {
+		const doc = parseDocument('Hello (world) today');
+		const parenWord = doc.words.find(w => w.raw.includes('world'));
+		expect(parenWord).toBeDefined();
+		expect(parenWord!.word).toBe('world');
+	});
+
+	it('extracts multiple headings', () => {
+		const doc = parseDocument('# Title 1\nSome text\n## Title 2\nMore text\n### Title 3\nEnd');
+		expect(doc.headings.length).toBe(3);
+		expect(doc.headings[0]!.level).toBe(1);
+		expect(doc.headings[1]!.level).toBe(2);
+		expect(doc.headings[2]!.level).toBe(3);
+	});
+
+	it('handles image syntax - alt text appears in words', () => {
+		const doc = parseDocument('Look at ![Photo](image.png) for reference');
+		const altWord = doc.words.find(w => w.word === 'Photo');
+		expect(altWord).toBeDefined();
+		const urlWord = doc.words.find(w => w.word.includes('image.png'));
+		expect(urlWord).toBeUndefined();
+	});
+
+	it('handles combined bold and italic', () => {
+		const doc = parseDocument('This is ***both*** formats');
+		const bothWord = doc.words.find(w => w.word === 'both');
+		expect(bothWord).toBeDefined();
+		expect(bothWord!.word).not.toContain('*');
+	});
+
+	it('handles strikethrough in word stream', () => {
+		const doc = parseDocument('This is ~~deleted~~ text');
+		const delWord = doc.words.find(w => w.word === 'deleted');
+		expect(delWord).toBeDefined();
+		expect(delWord!.word).not.toContain('~~');
+	});
+
+	it('does not split hyphenated words - tokenized as single tokens', () => {
+		const doc = parseDocument('Jean-Claude ran the marathon');
+		const hyphenated = doc.words.find(w => w.raw === 'Jean-Claude');
+		expect(hyphenated).toBeDefined();
+		expect(hyphenated!.word).toBe('Jean-Claude');
+	});
+
+	it('preserves underscores in variable-like words', () => {
+		const doc = parseDocument('Use my_variable to store data');
+		const varWord = doc.words.find(w => w.word === 'my_variable');
+		expect(varWord).toBeDefined();
+		expect(varWord!.word).toBe('my_variable');
+	});
+
+	it('preserves underscores in snake_case identifiers', () => {
+		const doc = parseDocument('Access my_long_variable_name here');
+		const varWord = doc.words.find(w => w.word === 'my_long_variable_name');
+		expect(varWord).toBeDefined();
+	});
+
+	it('still strips underscores used for italic markup', () => {
+		const doc = parseDocument('This is _italic_ text');
+		const italicWord = doc.words.find(w => w.word === 'italic');
+		expect(italicWord).toBeDefined();
+		const underWord = doc.words.find(w => w.raw === '_italic_');
+		expect(underWord).toBeUndefined();
+	});
+
+	it('preserves numbers with trailing punctuation', () => {
+		const doc = parseDocument('The count was 42.');
+		const numWord = doc.words.find(w => w.word === '42');
+		expect(numWord).toBeDefined();
+		expect(numWord!.punctuation).toBe('.');
+	});
+
+	it('handles words inside parentheses - strips parens for display', () => {
+		const doc = parseDocument('Hello (aside) world');
+		const asideWord = doc.words.find(w => w.raw === '(aside)');
+		expect(asideWord).toBeDefined();
+		expect(asideWord!.word).toBe('aside');
+	});
+
+	it('handles markdown link with nested formatting', () => {
+		const doc = parseDocument('[**bold link**](url) text');
+		const linkWord = doc.words.find(w => w.raw.includes('bold'));
+		expect(linkWord).toBeDefined();
+		expect(linkWord!.word).not.toContain('**');
+		expect(linkWord!.word).not.toContain('[');
+	});
+
+	it('handles multiple wiki links', () => {
+		const doc = parseDocument('See [[Note A]] and [[Note B|Display B]] here');
+		const bracketWords = doc.words.filter(w => w.word.includes('[[') || w.word.includes(']]'));
+		expect(bracketWords.length).toBe(0);
+	});
+
+	it('strips list markers and preserves content', () => {
+		const doc = parseDocument('- First item\n- Second item\n1. Numbered item');
+		const firstWord = doc.words.find(w => w.word === 'First');
+		expect(firstWord).toBeDefined();
+		const dashWord = doc.words.find(w => w.word === '-');
+		expect(dashWord).toBeUndefined();
+	});
+
+	it('strips leading parentheses from individual words', () => {
+		const doc = parseDocument('The result was (surprising) to everyone');
+		const parenWord = doc.words.find(w => w.word === 'surprising');
+		expect(parenWord).toBeDefined();
+		expect(parenWord!.word).not.toContain('(');
+		expect(parenWord!.word).not.toContain(')');
+	});
+
+	it('strips leading quote marks from words', () => {
+		const doc = parseDocument('"Quoted text" is here');
+		const quoteWord = doc.words.find(w => w.word === 'Quoted');
+		expect(quoteWord).toBeDefined();
+		expect(quoteWord!.word).not.toContain('"');
+	});
+
+	it('handles multi-word parenthetical text', () => {
+		const doc = parseDocument('Words (in this aside) appear here');
+		const asideIn = doc.words.find(w => w.word.includes('('));
+		expect(asideIn).toBeUndefined();
+	});
+
+	it('strips leading bracket from wiki link remnant tokens', () => {
+		const doc = parseDocument('See [[My Note]] for details');
+		const bracketWord = doc.words.find(w => w.word.includes('[') || w.word.includes(']'));
+		expect(bracketWord).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1

- **Strip markdown syntax** before tokenizing: bold, italic, code, links, images, wiki links, YAML frontmatter, code fences, headings, lists, blockquotes, highlights, strikethroughs, and comments no longer flash as raw text in the word stream
- **Preserve underscores** in `snake_case` identifiers while still stripping `_italic_` markup
- **Handle parenthetical text** — strips leading/trailing punctuation like `(aside)` so parens don't appear in display
- **Start reader paused** instead of auto-playing on open
- **Start from beginning** by default (new "Read entire note from cursor" command for cursor-based start)
- **Auto-pause on window blur** — pauses when switching away from Obsidian, resumes on return
- **Refocus content area** after button clicks for reliable keyboard shortcuts
- **Add configurable font size** setting (24–200px, default 64)

## Test plan

- [x] Markdown syntax stripped: `**bold**`, `*italic*`, `` `code` ``, `[[links]]`, `[text](url)`, `![img](src)`, YAML frontmatter, fenced code blocks, `#` headings, list markers, blockquotes
- [x] `my_variable` preserves underscores; `_italic_` strips them
- [x] `(aside)` shows "aside" without parens
- [x] Reader opens paused, press Space or ▶ to start
- [x] Auto-pause when switching windows, auto-resume on return
- [x] Font size setting applies correctly
- [x] 73 unit tests passing